### PR TITLE
Added instructions for password for correct deployment on Azure

### DIFF
--- a/tmpl-ambari-only/README.md
+++ b/tmpl-ambari-only/README.md
@@ -7,5 +7,6 @@
 [![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://azuredeploy.net/)
 
 3. Indicate username and password to be able to log into the KAVE. They should be at least **8 characters** long. Note that during the installation the password is stored in a plain text in log files, so make sure to change it after the cluster is up and running.
+    a. It is important to note that the password must not contain the characters like " ", "&", "\", "<" . Using any of these characters would put you into trouble, thus disabling you to run many of the services. Basically, it would start to fail for all.
 
 4. Indicate the names for your storage, premium storage and domain name prefix. These names should be unique and contain only a-z characters and numbers

--- a/tmpl-hdp-with-ci/README.md
+++ b/tmpl-hdp-with-ci/README.md
@@ -7,5 +7,5 @@
 [![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://azuredeploy.net/)
 
 3. Indicate username and password to be able to log into the KAVE. They should be at least **8 characters** long. Note that during the installation the password is stored in a plain text in log files, so make sure to change it after the cluster is up and running.
-
+    a. It is important to note that the password must not contain the characters like " ", "&", "\", "<" . Using any of these characters would put you into trouble, thus disabling you to run many of the services. Basically, it would start to fail for all.
 4. Indicate the names for your storage, premium storage and domain name prefix. These names should be unique and contain only a-z characters and numbers


### PR DESCRIPTION
I came across some errors when deploying kave on Azure. These errors were caused by some special characters in the password. I have added those instructions accordingly in the corresponding readme file(s). Now this can be merged with the the master branch. 
